### PR TITLE
Readme and wanip.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Copy the files of this repo under `/` directory of your Lede/Openwrt system.
 Set files as executable with commands:
 
 ```sh
-chmod +x -R /usr/lib/telegram-bot/* /usr/lib/telegram-bot/functions/*
+chmod +x -R /usr/lib/telegram-bot/* /usr/lib/telegram-bot/plugins/functions/*
 chmod +x /etc/init.d/telegram_bot
 service telegram_bot enable
 ```

--- a/usr/lib/telegram-bot/plugins/wanip.sh
+++ b/usr/lib/telegram-bot/plugins/wanip.sh
@@ -1,1 +1,1 @@
-nslookup myip.opendns.com resolver1.opendns.com | awk '/^Address( 1)?: / { print $3 }'
+curl https://ipinfo.io/ip


### PR DESCRIPTION
Fixed path to the `functions` folder in `README` since it's inside the `plugins` folder. 
`wanip.sh` didn't work for me, replaced it with a simpler and working command.